### PR TITLE
fix: typo in permissions keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     needs: [ ci, analyze ]
     runs-on: ubuntu-latest
     permissions:
-      content: write
+      contents: write
       issues: write
       pull-requests: write
     


### PR DESCRIPTION
Resolves `release.yml` workflow failing to run due to typo in one of the permissions keys
