### PR TITLE
ci: target next and release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+      - next
+      - release-**
 
 jobs:
   ci:


### PR DESCRIPTION
This PR adds `next` and `release-**` branches as `release.yml` trigger branches so that they can be released to their respective channels.