### PR TITLE
fix: run commitlint checks first

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-pnpx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-pnpm run build; pnpm run lint
+pnpx --no-install commitlint --edit $1
+pnpm run build
+pnpm run lint


### PR DESCRIPTION
This PR ensures that commitlint commit message linting checks run before all other checks